### PR TITLE
Purge node even if there is no parent branch

### DIFF
--- a/src/dom-id.js
+++ b/src/dom-id.js
@@ -237,7 +237,7 @@ exports.purgeNode = function(node){
 	var routeInfo = getCachedInfo(node);
 	if(!routeInfo) return;
 	var parentRouteInfo = getCachedInfo(node.parentNode);
-	if(parentRouteInfo) {
+	if(parentRouteInfo && parentRouteInfo.branch) {
 		var parentBranch = parentRouteInfo.branch;
 		var index = getIndex(routeInfo.id);
 
@@ -246,6 +246,8 @@ exports.purgeNode = function(node){
 		routeInfo.branch.length = 0;
 
 		nodeCache = {};
+	} else {
+		exports.purgeID(routeInfo.id);
 	}
 };
 
@@ -253,7 +255,7 @@ exports.purgeSiblings = function(node){
 	var routeInfo = getCachedInfo(node);
 	if(!routeInfo) return;
 	var parentRouteInfo = getCachedInfo(node.parentNode);
-	if(parentRouteInfo) {
+	if(parentRouteInfo && parentRouteInfo.branch) {
 		var parentBranch = parentRouteInfo.branch;
 		var index = getIndex(routeInfo.id);
 		var staleBranch = false;

--- a/test/test.js
+++ b/test/test.js
@@ -26,3 +26,14 @@ QUnit.test("finds the element at a route", function(){
 
 	equal(span, node, "Got the correct element");
 });
+
+QUnit.test("purges nodes correctly", function(){
+	var span = $("#qunit-test-area span")[0];
+	var node = nodeRoute.getNode(SPAN_ID);
+	var id = nodeRoute.getCachedID(node);
+
+	nodeRoute.purgeNode(node);
+	node.parentNode.removeChild(node);
+
+	QUnit.equal(nodeRoute.nodeCache[id], undefined, "Node was purged");
+});


### PR DESCRIPTION
If an entry in nodeCache is created from a call to `getNode` there won't
be a parentBranch, so we can't properly purge this node by looking at
the nodeTree. Instead just remove its entry directly from the nodeCache.
