### PR TITLE
Correctly purge siblings when Node is not already cached

### DIFF
--- a/src/dom-id.js
+++ b/src/dom-id.js
@@ -93,6 +93,8 @@ function getBranch(index, element, parentBranch) {
 	if(!branch) {
 		branch = parentBranch[index] = [];
 		branch.element = element;
+	} else if(branch.element !== element) {
+		branch.element = element;
 	}
 	return branch;
 }
@@ -253,14 +255,17 @@ exports.purgeNode = function(node){
 
 exports.purgeSiblings = function(node){
 	var routeInfo = getCachedInfo(node);
-	if(!routeInfo) return;
+	if(!routeInfo) {
+		exports.getID(node);
+		routeInfo = getCachedInfo(node);
+	}
 	var parentRouteInfo = getCachedInfo(node.parentNode);
 	if(parentRouteInfo && parentRouteInfo.branch) {
 		var parentBranch = parentRouteInfo.branch;
 		var index = getIndex(routeInfo.id);
 		var staleBranch = false;
 		parentBranch.forEach(function(branch, i){
-			if(i > index) {
+			if(i > index || (i === index && branch.element !== node)) {
 				// This branch is stale, remove it.
 				staleBranch = true;
 				return false;

--- a/src/dom-id.js
+++ b/src/dom-id.js
@@ -247,7 +247,7 @@ exports.purgeNode = function(node){
 		parentBranch.splice(index, 1);
 		routeInfo.branch.length = 0;
 
-		nodeCache = {};
+		nodeCache = exports.nodeCache = {};
 	} else {
 		exports.purgeID(routeInfo.id);
 	}
@@ -276,4 +276,9 @@ exports.purgeSiblings = function(node){
 			parentBranch[index] = routeInfo.branch;
 		}
 	}
+};
+
+exports.purgeCache = function(){
+	nodeCache = exports.nodeCache = {};
+	nodeTree = exports.nodeTree = [];
 };

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var $ = require("jquery");
 
 var SPAN_ID = "0.1.0.0.0.1.0";
 
-QUnit.module("dom-id", {
+QUnit.module("node-route", {
 	setup: function(){
 		nodeRoute.purgeID(SPAN_ID);
 		$("#qunit-test-area").html(

--- a/test/test.js
+++ b/test/test.js
@@ -37,3 +37,19 @@ QUnit.test("purges nodes correctly", function(){
 
 	QUnit.equal(nodeRoute.nodeCache[id], undefined, "Node was purged");
 });
+
+QUnit.test("purge sibilings works even with getNode", function(){
+	var firstLi = $("#qunit-test-area li")[0];
+	$(firstLi).attr("first", true);
+	// This should
+	nodeRoute.getID(firstLi);
+
+	var newLi = $("<li>")[0];
+	firstLi.parentNode.insertBefore(newLi, firstLi);
+
+	nodeRoute.purgeSiblings(newLi);
+
+	var parentBranch = nodeRoute.getCachedInfo(firstLi.parentNode).branch;
+
+	QUnit.equal(parentBranch[0].element, newLi, "Branch replaced with the new li");
+});


### PR DESCRIPTION
If a node is not cached we should still be able to find it's parent
branch and purge siblings.
