### PR TITLE
Export getRoute and add collapseTextNodes

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -53,3 +53,41 @@ QUnit.test("purge sibilings works even with getNode", function(){
 
 	QUnit.equal(parentBranch[0].element, newLi, "Branch replaced with the new li");
 });
+
+QUnit.module("getRoute")
+
+QUnit.test("{collapseTextNodes} returns information on sibling TextNodes", function(){
+	var ctn = function(v) { return document.createTextNode(v); };
+	var container = document.createElement("div");
+
+	var tn1 = ctn("One")
+	container.appendChild(tn1);
+
+	var tn2 = ctn("Two");
+	container.appendChild(tn2);
+
+	var info = nodeRoute.getRoute(tn2, { collapseTextNodes: true });
+
+	QUnit.equal(info.id, "0.0", "Found the right one");
+	QUnit.equal(info.value, "OneTwo", "Returned the value as well");
+});
+
+QUnit.test("{collapseTextNodes} works when there are elements mixins with text nodes", function(){
+	var ctn = function(v) { return document.createTextNode(v); };
+	var container = document.createElement("div");
+
+	container.appendChild(ctn("One"));
+	container.appendChild(ctn("Two"));
+	container.appendChild(document.createElement("span"));
+
+	var tn1 = ctn("Three")
+	container.appendChild(tn1);
+
+	var tn2 = ctn("Four");
+	container.appendChild(tn2);
+
+	var info = nodeRoute.getRoute(tn2, { collapseTextNodes: true });
+
+	QUnit.equal(info.id, "0.2", "Found the right one");
+	QUnit.equal(info.value, "ThreeFour", "Returned the value as well");
+});


### PR DESCRIPTION
This adds the `collapseTextNodes` option to `getRoute`. This is useful
if you want to ignore consecutive TextNodes when calculating a Node's
id, because the browser will collapse TextNodes when rendering HTML.

Closes #9