### PR TITLE
Whitespace should only be ignored for <head> elements

### DIFF
--- a/src/dom-id.js
+++ b/src/dom-id.js
@@ -127,12 +127,6 @@ exports.indexOfParent = function indexOfParent(parent, node){
 	return index;
 };
 
-var whitespaceExp = /^\s*$/;
-function isEmptyTextNode(node) {
-	var value = node.nodeValue;
-	return whitespaceExp.test(value);
-}
-
 /**
  * Generates the route for a particular node, caching the intermediate nodes
  * along the way.
@@ -149,14 +143,15 @@ function getRoute(node, options) {
 	}
 
 	var child = parent.firstChild;
-	var nextNodeType, prevNodeType, value;
+	var prevNodeType, siblingTag, value;
 	while(child) {
 		if(collapseTextNodes && child.nodeType === 3) {
-			nextNodeType = child.nextSibling && child.nextSibling.nodeType;
+			siblingTag = child.nextSibling && child.nextSibling.nodeName;
 			if(prevNodeType === 3) {
 				value += child.nodeValue;
 			}
-			else if(nextNodeType === 3 || !isEmptyTextNode(child)) {
+			// TextNodes before the <head> are ignored.
+			else if(siblingTag !== "HEAD") {
 				value = child.nodeValue;
 				index++;
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -95,17 +95,21 @@ QUnit.test("{collapseTextNodes} works when there are elements mixins with text n
 QUnit.test("{collapseTextNodes} ignores whitespace TextNodes", function(){
 	var cel = document.createElement.bind(document);
 	var ctn = document.createTextNode.bind(document);
-	var container = cel("div");
-
-	container.appendChild(cel("p"));
+	var container = cel("html");
 	container.appendChild(ctn(""));
-	container.appendChild(cel("span"));
-	container.appendChild(ctn("\n"));
+	container.appendChild(cel("head"));
+	var body = cel("body");
+	container.appendChild(body);
+
+	body.appendChild(cel("p"));
+	body.appendChild(ctn(""));
+	body.appendChild(cel("span"));
+	body.appendChild(ctn("\n"));
 
 	var last = cel("p");
-	container.appendChild(last);
+	body.appendChild(last);
 
 	var id = nodeRoute.getID(last, { collapseTextNodes: true });
 
-	QUnit.equal(id, "0.2", "correct id");
+	QUnit.equal(id, "0.1.4", "correct id");
 });


### PR DESCRIPTION
Only ignore empty whitespace when it proceeds the `<head>` element, so
that `documentElement.firstChild` points to the head. Other whitespace
TextNodes should be part of the count (unless collapsed). Closes #13